### PR TITLE
Fixing to_snake bug with numbers

### DIFF
--- a/camel_converter/__init__.py
+++ b/camel_converter/__init__.py
@@ -10,7 +10,7 @@ def to_camel(snake_string: str) -> str:
 
 
 def to_snake(camel_string: str) -> str:
-    words = findall("[a-zA-Z][^A-Z]*", camel_string)
+    words = findall("([a-zA-Z][^A-Z0-9]*|[0-9]+)", camel_string)
 
     return "_".join(word.lower() for word in words)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "camel-converter"
-version = "1.0.0"
+version = "1.0.1"
 description = "Converts a string from snake case to camel case or camel case to snake case"
 authors = ["Paul Sanders <psanders1@gmail.com>"]
 license = "MIT"

--- a/tests/test_camel_converter.py
+++ b/tests/test_camel_converter.py
@@ -3,22 +3,29 @@ import pytest
 from camel_converter import to_camel, to_snake, to_upper_camel
 
 
-def test_to_camel():
-    test_str = "this_is_a_test"
-    expected = "thisIsATest"
-
-    assert to_camel(test_str) == expected
-
-
-def test_to_upper_camel():
-    test_str = "this_is_a_test"
-    expected = "ThisIsATest"
-
-    assert to_upper_camel(test_str) == expected
+@pytest.mark.parametrize(
+    "test_str, expected_str",
+    [("this_is_a_test", "thisIsATest"), ("this_is_a_12_test", "thisIsA12Test")],
+)
+def test_to_camel(test_str, expected_str):
+    assert to_camel(test_str) == expected_str
 
 
-@pytest.mark.parametrize("test_str", ["thisIsATest", "ThisIsATest"])
-def test_to_snake(test_str):
-    expected = "this_is_a_test"
+@pytest.mark.parametrize(
+    "test_str, expected_str",
+    [("this_is_a_test", "ThisIsATest"), ("this_is_a_12_test", "ThisIsA12Test")],
+)
+def test_to_upper_camel(test_str, expected_str):
+    assert to_upper_camel(test_str) == expected_str
 
-    assert to_snake(test_str) == expected
+
+@pytest.mark.parametrize(
+    "test_str, expected_str",
+    [
+        ("thisIsATest", "this_is_a_test"),
+        ("ThisIsATest", "this_is_a_test"),
+        ("aTestWith12Number", "a_test_with_12_number"),
+    ],
+)
+def test_to_snake(test_str, expected_str):
+    assert to_snake(test_str) == expected_str


### PR DESCRIPTION
Fixed a bug in `to_snake` where strings with numbers weren't split at the number so `thisIsA12Number` would convert to `this_is_a12_number` rather than `this_is_a_12_number`.