### PR TITLE
optionally treat digits as capitals when converting to snake case

### DIFF
--- a/camel_converter/__init__.py
+++ b/camel_converter/__init__.py
@@ -111,16 +111,26 @@ def to_camel(snake_string: str) -> str:
 
 
 @lru_cache(maxsize=4096)
-def to_snake(camel_string: str) -> str:
+def to_snake(camel_string: str, treat_digits_as_capitals: bool = False) -> str:
     """Converts a camel case or pascal case string to snake case.
 
     Args:
-        camel_string: String in camel case or pascal case format. For example myVariable.
+        camel_string:
+            String in camel case or pascal case format. For example myVariable.
+        treat_digits_as_capitals:
+            Whether to treat digits as capitals. For example myVariable2 would become my_variable_2 rather than my_variable2.
 
     Returns:
         The string in snake case format. For example my_variable.
     """
-    return "".join([f"_{c}" if c.isupper() else c for c in camel_string]).lstrip("_").lower()
+
+    def check_character(c: str) -> str:
+        if c.isupper() or (treat_digits_as_capitals and c.isdigit()):
+            return f"_{c}"
+        else:
+            return c
+
+    return "".join([check_character(c) for c in camel_string]).lstrip("_").lower()
 
 
 @lru_cache(maxsize=4096)

--- a/camel_converter/__init__.py
+++ b/camel_converter/__init__.py
@@ -111,7 +111,7 @@ def to_camel(snake_string: str) -> str:
 
 
 @lru_cache(maxsize=4096)
-def to_snake(camel_string: str, treat_digits_as_capitals: bool = False) -> str:
+def to_snake(camel_string: str, *, treat_digits_as_capitals: bool = False) -> str:
     """Converts a camel case or pascal case string to snake case.
 
     Args:

--- a/tests/test_camel_converter.py
+++ b/tests/test_camel_converter.py
@@ -146,12 +146,14 @@ def test_to_pascal(test_str, expected_str):
 
 
 @pytest.mark.parametrize(
-    "test_str, expected_str",
+    "test_str, expected_str, treat_digits_as_capitals",
     [
-        ("thisIsATest", "this_is_a_test"),
-        ("ThisIsATest", "this_is_a_test"),
-        ("aTestWith12Number", "a_test_with12_number"),
+        ("thisIsATest", "this_is_a_test", False),
+        ("ThisIsATest", "this_is_a_test", False),
+        ("aTestWith12Number", "a_test_with12_number", False),
+        ("aTestWith12Number", "a_test_with_1_2_number", True),
+        ("ATestWith12Number", "a_test_with_1_2_number", True),
     ],
 )
-def test_to_snake(test_str, expected_str):
-    assert to_snake(test_str) == expected_str
+def test_to_snake(test_str, expected_str, treat_digits_as_capitals):
+    assert to_snake(test_str, treat_digits_as_capitals=treat_digits_as_capitals) == expected_str


### PR DESCRIPTION
Thanks for creating this, it's very useful

However, I discovered when using your package that I needed a slight variant on the `to_snake()` function. Specifically, I needed a camel case string like `myVariable2` to be converted to `my_variable_2` rather than `my_variable2`, so I tweaked your function to allow this. (The default behaviour remains the same so this should be backwards compatible)

Figured I should offer it back in case it is of use to other people. Feel free to take or leave it