### PR TITLE
Remove unneeded ruff target-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ check-unannotated-defs = false
 [tool.ruff]
 line-length = 100
 fix = true
-target-version = "py310"
 
 [tool.ruff.lint]
 select=[


### PR DESCRIPTION
ruff pulls this from requires-python now by default