### PR TITLE
Fix bug in dict conversion with nested lists

### DIFF
--- a/camel_converter/__init__.py
+++ b/camel_converter/__init__.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from functools import lru_cache
+from collections.abc import Callable
+from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any
 
 from camel_converter._version import VERSION
-
-__version__ = VERSION
 
 if TYPE_CHECKING:
     import sys
@@ -14,6 +13,8 @@ if TYPE_CHECKING:
         from typing import Self
     else:
         from typing_extensions import Self
+
+__version__ = VERSION
 
 
 class Converter:
@@ -81,24 +82,11 @@ def dict_to_camel(data: dict[Any, Any]) -> dict[Any, Any]:
 
     Returns:
         A dictionary with they keys of type string converted from snake case to camel case
+
+    Raises:
+        TypeError: If data is not a dict
     """
-    converted: dict[Any, Any] = {}
-    for k, v in data.items():
-        if isinstance(k, str):
-            key = to_camel(k)
-        else:
-            key = k
-
-        if isinstance(v, dict):
-            converted[key] = dict_to_camel(v)
-        elif isinstance(v, list):
-            converted[key] = [dict_to_camel(x) if isinstance(x, dict) else x for x in v]
-        elif isinstance(v, tuple):
-            converted[key] = tuple(dict_to_camel(x) if isinstance(x, dict) else x for x in v)
-        else:
-            converted[key] = v
-
-    return converted
+    return _convert_dict(data, to_camel)
 
 
 def dict_to_snake(
@@ -118,34 +106,11 @@ def dict_to_snake(
     Returns:
         A dictionary with they keys of type string converted from camel case or pascal case to
         snake case
+
+    Raises:
+        TypeError: If data is not a dict
     """
-    converted: dict[Any, Any] = {}
-    for k, v in data.items():
-        if isinstance(k, str):
-            key = to_snake(k, treat_digits_as_capitals=treat_digits_as_capitals)
-        else:
-            key = k
-
-        if isinstance(v, dict):
-            converted[key] = dict_to_snake(v, treat_digits_as_capitals=treat_digits_as_capitals)
-        elif isinstance(v, list):
-            converted[key] = [
-                dict_to_snake(x, treat_digits_as_capitals=treat_digits_as_capitals)
-                if isinstance(x, dict)
-                else x
-                for x in v
-            ]
-        elif isinstance(v, tuple):
-            converted[key] = tuple(
-                dict_to_snake(x, treat_digits_as_capitals=treat_digits_as_capitals)
-                if isinstance(x, dict)
-                else x
-                for x in v
-            )
-        else:
-            converted[key] = v
-
-    return converted
+    return _convert_dict(data, partial(to_snake, treat_digits_as_capitals=treat_digits_as_capitals))
 
 
 def dict_to_pascal(data: dict[Any, Any]) -> dict[Any, Any]:
@@ -158,24 +123,11 @@ def dict_to_pascal(data: dict[Any, Any]) -> dict[Any, Any]:
 
     Returns:
         A dictionary with they keys of type string converted from snake case to pascal case
+
+    Raises:
+        TypeError: If data is not a dict
     """
-    converted: dict[Any, Any] = {}
-    for k, v in data.items():
-        if isinstance(k, str):
-            key = to_pascal(k)
-        else:
-            key = k
-
-        if isinstance(v, dict):
-            converted[key] = dict_to_pascal(v)
-        elif isinstance(v, list):
-            converted[key] = [dict_to_pascal(x) if isinstance(x, dict) else x for x in v]
-        elif isinstance(v, tuple):
-            converted[key] = tuple(dict_to_pascal(x) if isinstance(x, dict) else x for x in v)
-        else:
-            converted[key] = v
-
-    return converted
+    return _convert_dict(data, to_pascal)
 
 
 @lru_cache(maxsize=4096)
@@ -234,3 +186,26 @@ def to_pascal(snake_string: str) -> str:
 
 def _split_snake(snake_string: str) -> list[str]:
     return snake_string.split("_")
+
+
+def _convert_dict(data: dict[Any, Any], convert_key: Callable[[str], str]) -> dict[Any, Any]:
+    if not isinstance(data, dict):
+        raise TypeError(f"Expected a dict, got {type(data).__name__}")
+
+    return _convert_value(data, convert_key)
+
+
+def _convert_value(value: Any, convert_key: Callable[[str], str]) -> Any:
+    if isinstance(value, dict):
+        return {
+            (convert_key(k) if isinstance(k, str) else k): _convert_value(v, convert_key)
+            for k, v in value.items()
+        }
+
+    if isinstance(value, list):
+        return [_convert_value(v, convert_key) for v in value]
+
+    if isinstance(value, tuple):
+        return tuple([_convert_value(v, convert_key) for v in value])
+
+    return value

--- a/tests/test_camel_converter.py
+++ b/tests/test_camel_converter.py
@@ -53,6 +53,26 @@ from camel_converter import (
             {"test_convert": ({"change_me": 1, "unchanged": 2}, 1)},
             {"testConvert": ({"changeMe": 1, "unchanged": 2}, 1)},
         ),
+        (
+            {"test_convert": [[{"change_me": 1, "unchanged": 2}, 1]]},
+            {"testConvert": [[{"changeMe": 1, "unchanged": 2}, 1]]},
+        ),
+        (
+            {"test_convert": [({"change_me": 1}, 1)]},
+            {"testConvert": [({"changeMe": 1}, 1)]},
+        ),
+        (
+            {"test_convert": ([{"change_me": 1}], 1)},
+            {"testConvert": ([{"changeMe": 1}], 1)},
+        ),
+        (
+            {"test_convert": [[[{"change_me": 1}]]]},
+            {"testConvert": [[[{"changeMe": 1}]]]},
+        ),
+        (
+            {"test_convert": [1, "two", None, {"change_me": 3}]},
+            {"testConvert": [1, "two", None, {"changeMe": 3}]},
+        ),
     ],
 )
 def test_dict_to_camel(test_dict, expected):
@@ -93,6 +113,26 @@ def test_dict_to_camel(test_dict, expected):
         (
             {"test_convert": ({"change_me": 1, "changed": 2}, 1)},
             {"TestConvert": ({"ChangeMe": 1, "Changed": 2}, 1)},
+        ),
+        (
+            {"test_convert": [[{"change_me": 1, "changed": 2}, 1]]},
+            {"TestConvert": [[{"ChangeMe": 1, "Changed": 2}, 1]]},
+        ),
+        (
+            {"test_convert": [({"change_me": 1}, 1)]},
+            {"TestConvert": [({"ChangeMe": 1}, 1)]},
+        ),
+        (
+            {"test_convert": ([{"change_me": 1}], 1)},
+            {"TestConvert": ([{"ChangeMe": 1}], 1)},
+        ),
+        (
+            {"test_convert": [[[{"change_me": 1}]]]},
+            {"TestConvert": [[[{"ChangeMe": 1}]]]},
+        ),
+        (
+            {"test_convert": [1, "two", None, {"change_me": 3}]},
+            {"TestConvert": [1, "two", None, {"ChangeMe": 3}]},
         ),
     ],
 )
@@ -145,6 +185,36 @@ def test_dict_to_pascal(test_dict, expected):
             False,
         ),
         (
+            {"testConvert": [[{"changeMe": 1, "unchanged": 2}, 1]]},
+            {"test_convert": [[{"change_me": 1, "unchanged": 2}, 1]]},
+            False,
+        ),
+        (
+            {"testConvert": [({"changeMe": 1},)]},
+            {"test_convert": [({"change_me": 1},)]},
+            False,
+        ),
+        (
+            {"testConvert": ([{"changeMe": 1}], 1)},
+            {"test_convert": ([{"change_me": 1}], 1)},
+            False,
+        ),
+        (
+            {"testConvert": [[[{"changeMe": 1}]]]},
+            {"test_convert": [[[{"change_me": 1}]]]},
+            False,
+        ),
+        (
+            {"testConvert": [1, "two", None, {"changeMe": 3}]},
+            {"test_convert": [1, "two", None, {"change_me": 3}]},
+            False,
+        ),
+        (
+            {"testConvert": [[{"changeMe12": 1}]]},
+            {"test_convert": [[{"change_me_1_2": 1}]]},
+            True,
+        ),
+        (
             {"aTestWith12Number": 1, "AnotherTestWith12Number": 2, "endNumber1": 3},
             {
                 "a_test_with_1_2_number": 1,
@@ -157,6 +227,13 @@ def test_dict_to_pascal(test_dict, expected):
 )
 def test_dict_to_snake(test_dict, expected, treat_digits_as_capitals):
     assert dict_to_snake(test_dict, treat_digits_as_capitals=treat_digits_as_capitals) == expected
+
+
+@pytest.mark.parametrize("converter", [dict_to_camel, dict_to_pascal, dict_to_snake])
+@pytest.mark.parametrize("test_data", ["some_string", ["some_key"], ("some_key",), 1, None])
+def test_dict_converters_non_dict_raises(converter, test_data):
+    with pytest.raises(TypeError, match="Expected a dict"):
+        converter(test_data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`dict_to_camel`, `dict_to_snake`, and `dict_to_pascal` would skip converting nested lists and tuples